### PR TITLE
Changed global string

### DIFF
--- a/Data.lua
+++ b/Data.lua
@@ -85,7 +85,7 @@ Data.FontOutlines = {
 
 Data.Buttons = {
     Target = TARGET,
-	Focus = FOCUS,
+	Focus = MINIMAP_TRACKING_FOCUS,
 	Custom = CHANNEL_CATEGORY_CUSTOM
 }
 


### PR DESCRIPTION
Changed global string FOCUS to MINIMAP_TRACKING_FOCUS.

Because Korean client's FOCUS value is hunter's resource name.

Global string that correct meaning focus target is MINIMAP_TRACKING_FOCUS.